### PR TITLE
Remove subscription management from Terraform

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -44,9 +44,6 @@ jobs:
       - name: Setup Terraform Files
         working-directory: environments/${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
         run: |
-          # Debug current values
-          echo "Environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}"
-
           # Create backend config
           cat > ../../backend.hcl << EOF
           bucket         = "${{ secrets.TF_STATE_BUCKET }}"
@@ -59,12 +56,10 @@ jobs:
           # Get the project path from GitHub workspace
           PROJECT_PATH="${GITHUB_REPOSITORY#*/}"
 
-          # Create tfvars with array format for subscriptions
+          # Create tfvars without subscription variables
           cat > terraform.tfvars << EOF
           aws_region                     = "${{ env.AWS_REGION }}"
           environment                    = "${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}"
-          email_addresses                = ${{ secrets[format('{0}_NOTIFICATION_EMAIL', github.event_name == 'workflow_dispatch' && inputs.environment || 'dev')] }}
-          phone_numbers                  = ${{ secrets[format('{0}_NOTIFICATION_PHONE', github.event_name == 'workflow_dispatch' && inputs.environment || 'dev')] }}
           terraform_state_bucket         = "${{ secrets.TF_STATE_BUCKET }}"
           terraform_state_key            = "health-notifications/${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}/terraform.tfstate"
           terraform_state_dynamodb_table = "${{ secrets.TF_STATE_LOCK_TABLE }}"
@@ -76,12 +71,6 @@ jobs:
             GithubRepo = "${PROJECT_PATH}"
           }
           EOF
-
-          # Debug generated files
-          echo "Backend config:"
-          cat ../../backend.hcl
-          echo "Terraform vars (with masked values):"
-          cat terraform.tfvars | sed 's/\(email_addresses.*=\).*/\1 [***]/g; s/\(phone_numbers.*=\).*/\1 [***]/g'
 
       - name: Terraform Init
         working-directory: environments/${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
@@ -135,12 +124,10 @@ jobs:
           # Get the project path from GitHub workspace
           PROJECT_PATH="${GITHUB_REPOSITORY#*/}"
 
-          # Create tfvars with array format for subscriptions
+          # Create tfvars without subscription variables
           cat > terraform.tfvars << EOF
           aws_region                     = "${{ env.AWS_REGION }}"
           environment                    = "${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}"
-          email_addresses                = ${{ secrets[format('{0}_NOTIFICATION_EMAIL', github.event_name == 'workflow_dispatch' && inputs.environment || 'dev')] }}
-          phone_numbers                  = ${{ secrets[format('{0}_NOTIFICATION_PHONE', github.event_name == 'workflow_dispatch' && inputs.environment || 'dev')] }}
           terraform_state_bucket         = "${{ secrets.TF_STATE_BUCKET }}"
           terraform_state_key            = "health-notifications/${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}/terraform.tfstate"
           terraform_state_dynamodb_table = "${{ secrets.TF_STATE_LOCK_TABLE }}"

--- a/README.md
+++ b/README.md
@@ -1,208 +1,41 @@
-# AWS Health Event Notifications Infrastructure
+## Managing Subscriptions
 
-This project automates AWS Health Event notifications using Terraform and GitHub Actions, supporting multiple environments with customizable email and SMS alerts.
+SNS topic subscriptions are managed manually through the AWS Console, not through Terraform. This approach provides more flexibility and avoids issues with subscription confirmation and state management.
 
-## Features
+### Adding Email Subscriptions
 
-- 🔔 Real-time AWS Health Event notifications
-- 📧 Email and SMS notification channels
-- 🌍 Multi-environment support (dev/prod)
-- 🔄 Automated deployments via GitHub Actions
-- 🔒 State management with S3 and DynamoDB
-- 📝 Custom message formatting per channel
-- 🏗️ Modular Terraform architecture
+1. Navigate to the AWS SNS Console
+2. Find the topic: `{environment}-health-event-notifications`
+3. Click "Create subscription"
+4. Choose:
+   - Protocol: Email
+   - Endpoint: Enter the email address
+5. Click "Create subscription"
+6. Check the email inbox and confirm the subscription
 
-## Architecture
+### Adding SMS Subscriptions
 
-```
-AWS Health Events → EventBridge → SNS Topic → Email/SMS Subscribers
-```
+1. Navigate to the AWS SNS Console
+2. Find the topic: `{environment}-health-event-notifications`
+3. Click "Create subscription"
+4. Choose:
+   - Protocol: SMS
+   - Endpoint: Enter the phone number in E.164 format (e.g., +14155551234)
+5. Click "Create subscription"
 
-- **Amazon EventBridge**: Captures and filters AWS Health events
-- **Amazon SNS**: Manages notification distribution
-- **Terraform**: Infrastructure as Code
-- **GitHub Actions**: CI/CD automation
+### Managing Existing Subscriptions
 
-## Project Structure
+1. Go to the SNS topic in AWS Console
+2. Click on the "Subscriptions" tab
+3. You can:
+   - Delete subscriptions
+   - View delivery status
+   - Check subscription attributes
 
-```
-.
-├── environments/
-│   ├── dev/            # Development environment
-│   └── prod/           # Production environment
-├── modules/
-│   ├── eventbridge/    # Event processing module
-│   └── sns/            # Notification management module
-├── backend/            # Backend configurations
-├── .github/workflows/  # CI/CD pipeline
-└── scripts/            # Helper scripts
-```
+### Benefits of Manual Management
 
-## Prerequisites
-
-- AWS Account with administrative access
-- GitHub repository access
-- Terraform v1.10.1 or higher
-- AWS CLI configured locally
-- S3 bucket for Terraform state
-- DynamoDB table for state locking
-
-## GitHub Setup
-
-### 1. Configure Environments
-
-Create two GitHub environments: `dev` and `prod`.
-
-### 2. Environment Secrets
-
-For each environment, add:
-
-```
-<ENV>_NOTIFICATION_EMAIL: ["email1@example.com", "email2@example.com"]
-<ENV>_NOTIFICATION_PHONE: ["+1234567890", "+0987654321"]
-```
-
-### 3. Repository Secrets
-
-```
-AWS_ACCESS_KEY_ID: Your AWS access key
-AWS_SECRET_ACCESS_KEY: Your AWS secret key
-TF_STATE_BUCKET: Your S3 bucket name
-TF_STATE_LOCK_TABLE: Your DynamoDB table name
-```
-
-## Local Development
-
-### 1. Clone the Repository
-
-```bash
-git clone <repository-url>
-cd aws-health-notifications
-```
-
-### 2. Initialize Environment
-
-```bash
-# Use the init script for automated setup
-./init.sh dev
-
-# Or manually:
-cd environments/dev
-terraform init -backend-config=../../backend/dev.hcl
-```
-
-### 3. Create tfvars File
-
-Copy the example and customize:
-
-```bash
-cp terraform.tfvars.example terraform.tfvars
-# Edit terraform.tfvars with your values
-```
-
-### 4. Deploy Locally
-
-```bash
-# Using the deploy script
-./deploy.sh dev
-
-# Or manually:
-terraform plan
-terraform apply
-```
-
-## CI/CD Pipeline
-
-### Automated Deployments
-
-- **Pull Requests**: Terraform plan only (for review)
-- **Push to main**: Automatic deployment to dev
-- **Manual trigger**: Select environment for deployment
-
-### Deployment Flow
-
-1. Create feature branch
-2. Make changes
-3. Create pull request
-4. Review Terraform plan
-5. Merge to main
-6. Automatic deployment (dev) or manual approval (prod)
-
-### Production Deployments
-
-Production requires manual approval through GitHub environments:
-
-1. Merge PR to main
-2. GitHub Actions runs Terraform plan
-3. Review and approve deployment in GitHub UI
-4. Terraform apply executes
-
-## Notification Formats
-
-### Email Notifications
-
-Detailed information including:
-
-- Environment name
-- Event details and description
-- Affected service
-- Time information
-- AWS account and region
-
-### SMS Notifications
-
-Concise format:
-
-```
-[Environment] AWS Health Alert: <Service> is <Status>. <Description>
-```
-
-## Best Practices
-
-1. **Testing**: Always test changes in dev before prod
-2. **Reviews**: Require PR reviews for all changes
-3. **Monitoring**: Watch CloudWatch logs for event processing
-4. **Validation**: Verify SNS subscriptions after deployment
-5. **Documentation**: Keep tfvars.example updated
-
-## Troubleshooting
-
-### Common Issues
-
-1. **Failed Terraform Init**
-
-   - Check S3 bucket permissions
-   - Verify DynamoDB table exists
-   - Confirm AWS credentials
-
-2. **Subscription Confirmation**
-
-   - Check spam folders for confirmation emails
-   - Verify phone numbers are in E.164 format
-
-3. **No Notifications Received**
-   - Confirm EventBridge rule is active
-   - Check SNS topic permissions
-   - Review CloudWatch logs
-
-## Support
-
-- Check GitHub Actions logs for deployment issues
-- Review AWS CloudWatch for event processing logs
-- Contact the platform team for assistance
-
-## License
-
-MIT License
-
-## Contributing
-
-1. Fork the repository
-2. Create a feature branch
-3. Make changes and test thoroughly
-4. Submit a pull request
-5. Wait for review and approval
-
-## Changelog
-
-See [deployment.md](deployment.md) for detailed deployment procedures.
+- No Terraform state issues with confirmations
+- Easy to add/remove subscriptions without code changes
+- No deployment required for subscription changes
+- Avoid issues with phone number formatting in code
+- Team members can manage their own subscriptions

--- a/environments/dev/backup_module.sns.aws_sns_topic_subscription.email_subscriptions["jxman@hotmail.com"].json
+++ b/environments/dev/backup_module.sns.aws_sns_topic_subscription.email_subscriptions["jxman@hotmail.com"].json
@@ -1,0 +1,20 @@
+# module.sns.aws_sns_topic_subscription.email_subscriptions["jxman@hotmail.com"]:
+resource "aws_sns_topic_subscription" "email_subscriptions" {
+    arn                             = "arn:aws:sns:us-east-1:600424110307:dev-health-event-notifications:b31ee980-86d3-41c1-8638-72d5c1efbc2b"
+    confirmation_timeout_in_minutes = 1
+    confirmation_was_authenticated  = false
+    delivery_policy                 = [90mnull[0m[0m
+    endpoint                        = "jxman@hotmail.com"
+    endpoint_auto_confirms          = false
+    filter_policy                   = [90mnull[0m[0m
+    filter_policy_scope             = [90mnull[0m[0m
+    id                              = "arn:aws:sns:us-east-1:600424110307:dev-health-event-notifications:b31ee980-86d3-41c1-8638-72d5c1efbc2b"
+    owner_id                        = "600424110307"
+    pending_confirmation            = false
+    protocol                        = "email"
+    raw_message_delivery            = false
+    redrive_policy                  = [90mnull[0m[0m
+    replay_policy                   = [90mnull[0m[0m
+    subscription_role_arn           = [90mnull[0m[0m
+    topic_arn                       = "arn:aws:sns:us-east-1:600424110307:dev-health-event-notifications"
+}

--- a/environments/dev/backup_module.sns.aws_sns_topic_subscription.sms_subscriptions["+18572722763"].json
+++ b/environments/dev/backup_module.sns.aws_sns_topic_subscription.sms_subscriptions["+18572722763"].json
@@ -1,0 +1,20 @@
+# module.sns.aws_sns_topic_subscription.sms_subscriptions["+18572722763"]:
+resource "aws_sns_topic_subscription" "sms_subscriptions" {
+    arn                             = "arn:aws:sns:us-east-1:600424110307:dev-health-event-notifications:e3885505-e1c8-4951-9d9e-67a1455f004f"
+    confirmation_timeout_in_minutes = 1
+    confirmation_was_authenticated  = true
+    delivery_policy                 = [90mnull[0m[0m
+    endpoint                        = "+18572722763"
+    endpoint_auto_confirms          = false
+    filter_policy                   = [90mnull[0m[0m
+    filter_policy_scope             = [90mnull[0m[0m
+    id                              = "arn:aws:sns:us-east-1:600424110307:dev-health-event-notifications:e3885505-e1c8-4951-9d9e-67a1455f004f"
+    owner_id                        = "600424110307"
+    pending_confirmation            = false
+    protocol                        = "sms"
+    raw_message_delivery            = false
+    redrive_policy                  = [90mnull[0m[0m
+    replay_policy                   = [90mnull[0m[0m
+    subscription_role_arn           = [90mnull[0m[0m
+    topic_arn                       = "arn:aws:sns:us-east-1:600424110307:dev-health-event-notifications"
+}

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -17,10 +17,8 @@ provider "aws" {
 module "sns" {
   source = "../../modules/sns"
 
-  environment     = var.environment
-  email_addresses = var.email_addresses
-  phone_numbers   = var.phone_numbers
-  tags            = var.tags
+  environment = var.environment
+  tags        = var.tags
 }
 
 module "eventbridge" {

--- a/environments/dev/terraform.tfvars.example
+++ b/environments/dev/terraform.tfvars.example
@@ -1,7 +1,5 @@
 aws_region                     = "us-east-1"
 environment                    = "dev"  # or "prod"
-email_addresses                = ["email1@example.com", "email2@example.com"]
-phone_numbers                  = ["+1234567890"]
 terraform_state_bucket         = "your-terraform-state-bucket"
 terraform_state_key            = "health-notifications/{environment}/terraform.tfstate"
 terraform_state_dynamodb_table = "your-terraform-lock-table"
@@ -12,4 +10,3 @@ tags = {
   ManagedBy   = "terraform"
   Owner       = "platform-team"
 }
-

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -1,24 +1,13 @@
-variable "aws_region" {
-  description = "AWS Region"
-  type        = string
-  default     = "us-east-1"
-}
-
 variable "environment" {
   description = "Environment name"
   type        = string
   default     = "dev"
 }
 
-variable "email_addresses" {
-  description = "List of email addresses for notifications"
-  type        = list(string)
-}
-
-variable "phone_numbers" {
-  description = "List of phone numbers for SMS notifications"
-  type        = list(string)
-  default     = []
+variable "aws_region" {
+  description = "AWS Region"
+  type        = string
+  default     = "us-east-1"
 }
 
 variable "terraform_state_bucket" {
@@ -37,11 +26,10 @@ variable "terraform_state_dynamodb_table" {
 }
 
 variable "tags" {
-  description = "Resource tags"
+  description = "Default tags for all resources"
   type        = map(string)
   default = {
     Environment = "dev"
     Service     = "aws-health-notifications"
-    ManagedBy   = "terraform"
   }
 }

--- a/environments/prod/backup_module.sns.aws_sns_topic_subscription.email_subscriptions["john.xanthopoulos@mmc.com"].json
+++ b/environments/prod/backup_module.sns.aws_sns_topic_subscription.email_subscriptions["john.xanthopoulos@mmc.com"].json
@@ -1,0 +1,20 @@
+# module.sns.aws_sns_topic_subscription.email_subscriptions["john.xanthopoulos@mmc.com"]:
+resource "aws_sns_topic_subscription" "email_subscriptions" {
+    arn                             = "arn:aws:sns:us-east-1:600424110307:prod-health-event-notifications:1fde1501-e39f-4527-9385-a738f07004a9"
+    confirmation_timeout_in_minutes = 1
+    confirmation_was_authenticated  = false
+    delivery_policy                 = [90mnull[0m[0m
+    endpoint                        = "john.xanthopoulos@mmc.com"
+    endpoint_auto_confirms          = false
+    filter_policy                   = [90mnull[0m[0m
+    filter_policy_scope             = [90mnull[0m[0m
+    id                              = "arn:aws:sns:us-east-1:600424110307:prod-health-event-notifications:1fde1501-e39f-4527-9385-a738f07004a9"
+    owner_id                        = "600424110307"
+    pending_confirmation            = true
+    protocol                        = "email"
+    raw_message_delivery            = false
+    redrive_policy                  = [90mnull[0m[0m
+    replay_policy                   = [90mnull[0m[0m
+    subscription_role_arn           = [90mnull[0m[0m
+    topic_arn                       = "arn:aws:sns:us-east-1:600424110307:prod-health-event-notifications"
+}

--- a/environments/prod/backup_module.sns.aws_sns_topic_subscription.email_subscriptions["jxman@hotmail.com"].json
+++ b/environments/prod/backup_module.sns.aws_sns_topic_subscription.email_subscriptions["jxman@hotmail.com"].json
@@ -1,0 +1,20 @@
+# module.sns.aws_sns_topic_subscription.email_subscriptions["jxman@hotmail.com"]:
+resource "aws_sns_topic_subscription" "email_subscriptions" {
+    arn                             = "arn:aws:sns:us-east-1:600424110307:prod-health-event-notifications:f561d52c-bc1b-41b9-9248-25fe850f0e4f"
+    confirmation_timeout_in_minutes = 1
+    confirmation_was_authenticated  = false
+    delivery_policy                 = [90mnull[0m[0m
+    endpoint                        = "jxman@hotmail.com"
+    endpoint_auto_confirms          = false
+    filter_policy                   = [90mnull[0m[0m
+    filter_policy_scope             = [90mnull[0m[0m
+    id                              = "arn:aws:sns:us-east-1:600424110307:prod-health-event-notifications:f561d52c-bc1b-41b9-9248-25fe850f0e4f"
+    owner_id                        = "600424110307"
+    pending_confirmation            = false
+    protocol                        = "email"
+    raw_message_delivery            = false
+    redrive_policy                  = [90mnull[0m[0m
+    replay_policy                   = [90mnull[0m[0m
+    subscription_role_arn           = [90mnull[0m[0m
+    topic_arn                       = "arn:aws:sns:us-east-1:600424110307:prod-health-event-notifications"
+}

--- a/environments/prod/backup_module.sns.aws_sns_topic_subscription.sms_subscriptions["+18572722763"].json
+++ b/environments/prod/backup_module.sns.aws_sns_topic_subscription.sms_subscriptions["+18572722763"].json
@@ -1,0 +1,20 @@
+# module.sns.aws_sns_topic_subscription.sms_subscriptions["+18572722763"]:
+resource "aws_sns_topic_subscription" "sms_subscriptions" {
+    arn                             = "arn:aws:sns:us-east-1:600424110307:prod-health-event-notifications:1b99f503-c9f2-4622-b9a0-6bd9337a8ff5"
+    confirmation_timeout_in_minutes = 1
+    confirmation_was_authenticated  = true
+    delivery_policy                 = [90mnull[0m[0m
+    endpoint                        = "+18572722763"
+    endpoint_auto_confirms          = false
+    filter_policy                   = [90mnull[0m[0m
+    filter_policy_scope             = [90mnull[0m[0m
+    id                              = "arn:aws:sns:us-east-1:600424110307:prod-health-event-notifications:1b99f503-c9f2-4622-b9a0-6bd9337a8ff5"
+    owner_id                        = "600424110307"
+    pending_confirmation            = false
+    protocol                        = "sms"
+    raw_message_delivery            = false
+    redrive_policy                  = [90mnull[0m[0m
+    replay_policy                   = [90mnull[0m[0m
+    subscription_role_arn           = [90mnull[0m[0m
+    topic_arn                       = "arn:aws:sns:us-east-1:600424110307:prod-health-event-notifications"
+}

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -17,10 +17,8 @@ provider "aws" {
 module "sns" {
   source = "../../modules/sns"
 
-  environment     = var.environment
-  email_addresses = var.email_addresses
-  phone_numbers   = var.phone_numbers
-  tags            = var.tags
+  environment = var.environment
+  tags        = var.tags
 }
 
 module "eventbridge" {

--- a/environments/prod/terraform.tfvars.example
+++ b/environments/prod/terraform.tfvars.example
@@ -1,7 +1,5 @@
 aws_region                     = "us-east-1"
 environment                    = "dev"  # or "prod"
-email_addresses                = ["email1@example.com", "email2@example.com"]
-phone_numbers                  = ["+1234567890"]
 terraform_state_bucket         = "your-terraform-state-bucket"
 terraform_state_key            = "health-notifications/{environment}/terraform.tfstate"
 terraform_state_dynamodb_table = "your-terraform-lock-table"
@@ -12,4 +10,3 @@ tags = {
   ManagedBy   = "terraform"
   Owner       = "platform-team"
 }
-

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -10,17 +10,6 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
-variable "email_addresses" {
-  description = "List of email addresses for notifications"
-  type        = list(string)
-}
-
-variable "phone_numbers" {
-  description = "List of phone numbers for SMS notifications"
-  type        = list(string)
-  default     = []
-}
-
 variable "terraform_state_bucket" {
   description = "S3 bucket for storing terraform state"
   type        = string
@@ -35,6 +24,7 @@ variable "terraform_state_dynamodb_table" {
   description = "DynamoDB table for terraform state locking"
   type        = string
 }
+
 variable "tags" {
   description = "Default tags for all resources"
   type        = map(string)

--- a/migrate-subscriptions.sh
+++ b/migrate-subscriptions.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Migration script to remove subscription management from Terraform
+# This script removes existing subscriptions from Terraform state
+
+echo "AWS Health Notifications - Subscription Migration Script"
+echo "======================================================"
+
+# Check if environment is provided
+if [ -z "$1" ]; then
+    echo "Usage: ./migrate-subscriptions.sh <environment>"
+    echo "Example: ./migrate-subscriptions.sh dev"
+    exit 1
+fi
+
+ENV=$1
+ENV_DIR="environments/$ENV"
+
+# Check if environment exists
+if [ ! -d "$ENV_DIR" ]; then
+    echo "Error: Environment '$ENV' not found"
+    exit 1
+fi
+
+cd "$ENV_DIR" || exit
+
+echo "Working in environment: $ENV"
+echo "Initializing Terraform..."
+
+# Initialize Terraform
+terraform init -backend-config="../../backend/$ENV.hcl"
+
+echo -e "\nCurrent subscriptions in Terraform state:"
+terraform state list | grep subscription || echo "No subscriptions found in state"
+
+# Store subscriptions before removal
+echo -e "\nBacking up subscription details..."
+terraform state list | grep subscription | while read -r resource; do
+    echo "Resource: $resource"
+    terraform state show "$resource" > "backup_${resource//\//_}.json"
+done
+
+echo -e "\nRemoving subscriptions from Terraform state..."
+echo "This will NOT delete the actual subscriptions from AWS."
+
+# Remove email subscriptions
+terraform state list | grep "email_subscriptions" | while read -r resource; do
+    echo "Removing: $resource"
+    terraform state rm "$resource"
+done
+
+# Remove SMS subscriptions
+terraform state list | grep "sms_subscriptions" | while read -r resource; do
+    echo "Removing: $resource"
+    terraform state rm "$resource"
+done
+
+echo -e "\nSubscriptions removed from Terraform state."
+echo "The actual subscriptions still exist in AWS and will continue to work."
+echo -e "\nNext steps:"
+echo "1. Update your Terraform code to remove subscription resources"
+echo "2. Run 'terraform plan' to verify no subscriptions will be destroyed"
+echo "3. Apply the changes"
+echo "4. Manage subscriptions manually through AWS Console"
+
+echo -e "\nBackup files created in: $ENV_DIR"
+ls backup_*.json 2>/dev/null || echo "No backup files created"

--- a/modules/sns/main.tf
+++ b/modules/sns/main.tf
@@ -1,26 +1,10 @@
-# Purpose: Create an SNS topic and subscriptions for AWS Health events
+# Purpose: Create an SNS topic for AWS Health events (subscriptions managed manually)
 
 # SNS Topic for Health Events
 resource "aws_sns_topic" "health_events" {
   name         = "${var.environment}-health-event-notifications"
   display_name = "AWS Health Events - ${var.environment}"
   tags         = var.tags
-}
-
-# Email Subscriptions
-resource "aws_sns_topic_subscription" "email_subscriptions" {
-  for_each  = toset(var.email_addresses)
-  topic_arn = aws_sns_topic.health_events.arn
-  protocol  = "email"
-  endpoint  = each.value
-}
-
-# SMS Subscriptions
-resource "aws_sns_topic_subscription" "sms_subscriptions" {
-  for_each  = toset(var.phone_numbers)
-  topic_arn = aws_sns_topic.health_events.arn
-  protocol  = "sms"
-  endpoint  = each.value
 }
 
 # SNS Topic Policy

--- a/modules/sns/variables.tf
+++ b/modules/sns/variables.tf
@@ -3,18 +3,6 @@ variable "environment" {
   type        = string
 }
 
-variable "email_addresses" {
-  description = "List of email addresses for notifications"
-  type        = list(string)
-  default     = []
-}
-
-variable "phone_numbers" {
-  description = "List of phone numbers for SMS notifications (E.164 format)"
-  type        = list(string)
-  default     = []
-}
-
 variable "tags" {
   description = "Resource tags"
   type        = map(string)


### PR DESCRIPTION
This PR removes subscription management from Terraform code.

## Changes
- Removed subscription resources from SNS module
- Removed subscription-related variables
- Updated GitHub Actions workflow
- Added documentation for manual subscription management

## Migration Process
1. Run migration script to remove subscriptions from state
2. Update code with these changes
3. Verify plan shows no destructions
4. Apply changes
5. Manage subscriptions manually via AWS Console

## Benefits
- Eliminates subscription confirmation issues
- Removes state management problems
- Allows flexible subscription management
- No deployments needed for subscription changes